### PR TITLE
Develop

### DIFF
--- a/lang/lang_fr.php
+++ b/lang/lang_fr.php
@@ -4,7 +4,7 @@
 # Date : 08/01/2010
 # Version : 1.70
 
-$lang['menu_cdr'] = "Champs de ruines";
+$lang['menu_cdr'] = "CdR";
 $lang['menu_option'] = "Option";
 $lang['coord'] = "Coordonnées";
 $lang['nb_recy'] = "Nombre de recycleurs";

--- a/lang/lang_french.php
+++ b/lang/lang_french.php
@@ -1,5 +1,5 @@
 <?php
-$lang['menu_cdr'] = "Champs de ruines";
+$lang['menu_cdr'] = "CdR";
 $lang['menu_option'] = "Option";
 $lang['coord'] = " Coordonnées ";
 $lang['nb_recy'] = " Nb de recycleurs ";


### PR DESCRIPTION
L'intitulé du mod dans le menu est trop long et se retrouve sur deux lignes dans la liste des modules de OGSpy. CdR est compréhensible par tout joueur d'ogame, mais un autre intitulé peut faire l'affaire tant qu'il est moins long.